### PR TITLE
Judging logic changes

### DIFF
--- a/src/__tests__/judging.test.ts
+++ b/src/__tests__/judging.test.ts
@@ -252,7 +252,7 @@ describe('rate hacks', () => {
                 expect(e.text).toContain("already has a review");
             });
     });
-    test('rate a hack with three reviews already - fail', async () => {
+    test('rate a hack with three reviews already - success', async () => {
         await new Hack({
             _id: 1,
             reviews: [{}, {}, {}],
@@ -267,10 +267,7 @@ describe('rate hacks', () => {
                 socialImpact: 3,
                 comments: "test"
             })
-            .expect(403)
-            .then(e => {
-                expect(e.text).toContain("already has 3 reviews");
-            });
+            .expect(200);
     });
 });
 

--- a/src/routes/hacks/judging.ts
+++ b/src/routes/hacks/judging.ts
@@ -35,10 +35,6 @@ export const rateHack = async (req, res) => {
     if (!hack) {
         return res.status(404).send("Hack to rate not found");
     }
-    // TODO: change the max number of reviews?
-    else if (hack.reviews && hack.reviews.length >= 3) {
-        return res.status(403).send("Hack already has 3 reviews.");
-    }
     else if (hack.reviews && find(hack.reviews, { "reader": { "id": res.locals.user.sub } })) {
         return res.status(403).send("Hack already has a review submitted by user " + res.locals.user.sub);
     }

--- a/src/routes/hacks/judging.ts
+++ b/src/routes/hacks/judging.ts
@@ -70,7 +70,7 @@ export const reviewNextHack = async (req, res) => {
                 $and: [
                     { 'reviews.reader.id': { $ne: res.locals.user.sub } }, // Not already reviewed by current user
                     categories && categories.length ? { 'categories': { $in: categories } } : {},
-                    { ['reviews.2']: { $exists: false } }, // Look for when length of "reviews" is less than 3.
+                    { 'reviews.2': { $exists: false } }, // Look for when length of "reviews" is less than 3.
                 ]
             }
         },


### PR DESCRIPTION
Fixes backend logic changes for https://github.com/TreeHacks/application-portal-frontend/issues/40

- Allow a hack to be rated even if it already has 3 reviews
- Prefer to pick hacks with less reviews first. -- note the way I did this; the way I did it doesn't guarantee randomness.
   - The only way I see to guarantee randomness would be to have (up to) four different queries per call of the `next_hack` endpoint:
      1. find hacks with specified verticals and 1 review
      1. find hacks with specified verticals and 2 reviews
      1. find hacks with any verticals and 1 review
      1. find hacks with any verticals and 2 reviews
   - And that didn't seem worth it. We can change the logic to be that way though.